### PR TITLE
Fixing build.zig for 0.12.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -34,8 +34,8 @@ pub fn build(b: *std.Build) void {
         .file = .{ .path = "src/base/ftmac.c" },
         .flags = &.{},
     });
-    lib.installHeadersDirectory("include/freetype", "freetype");
-    lib.installHeader("include/ft2build.h", "ft2build.h");
+    lib.installHeadersDirectory(b.path("include/freetype"), "freetype", .{});
+    lib.installHeader(b.path("include/ft2build.h"), "ft2build.h");
     b.installArtifact(lib);
 }
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -13,8 +13,9 @@
     },
     .dependencies = .{
         .brotli = .{
-            .url = "https://pkg.machengine.org/brotli/538f4c5b085bb53c84e39860305442abd0436be5.tar.gz",
-            .hash = "12202a0f156a1d5d25a97468de318a99451a77b930f584d4edeff152259a875a4a75",
+            // .url = "https://pkg.machengine.org/brotli/538f4c5b085bb53c84e39860305442abd0436be5.tar.gz",
+            .url = "https://github.com/srjilarious/brotli/archive/7e9f8b1.tar.gz",
+            .hash = "122006cd44aff7dc0daeb2b7800413268f6440ce8e51106febeca80d876288303990",
             .lazy = true,
         },
     },


### PR DESCRIPTION
# Description

In my own little game project, I've been using `mach-freetype` as a dependency to do text rendering.  I was upgrading my project to use zig 0.12.0 and I noticed that this dependency, as well as its dependency `brotli` needed some small changes to the `build.zig`.

This PR is related to the [PR to fix brotli for 0.12.0](https://github.com/hexops/brotli/pull/18)

# Issue

With Zig 0.12.0, the current `master` branch fails to build:
```
$ zig version
0.12.0

$ /home/srjilarious/code/oss/freetype/build.zig:37:8: error: member function expected 3 argument(s), found 2
    lib.installHeadersDirectory("include/freetype", "freetype");
    ~~~^~~~~~~~~~~~~~~~~~~~~~~~
/home/srjilarious/.zvm/0.12.0/lib/std/Build/Step/Compile.zig:471:5: note: function declared here
pub fn installHeadersDirectory(
~~~~^~
referenced by:
    runBuild__anon_8992: /home/srjilarious/.zvm/0.12.0/lib/std/Build.zig:2079:27
    main: /home/srjilarious/.zvm/0.12.0/lib/compiler/build_runner.zig:300:29
    remaining reference traces hidden; use '-freference-trace' to see all reference traces
/home/srjilarious/.cache/zig/p/12202a0f156a1d5d25a97468de318a99451a77b930f584d4edeff152259a875a4a75/build.zig:16:8: error: member function expected 3 argument(s), found 2
    lib.installHeadersDirectory("c/include/brotli", "brotli");
    ~~~^~~~~~~~~~~~~~~~~~~~~~~~
/home/srjilarious/.zvm/0.12.0/lib/std/Build/Step/Compile.zig:471:5: note: function declared here
pub fn installHeadersDirectory(
~~~~^~
```

with this PR, `zig build` now works as expected.

# Changes

The only real change is creating a [LazyPath](https://ziglang.org/documentation/master/std/#std.Build.LazyPath) for the source parameter to [installHeadersDirectory](https://ziglang.org/documentation/master/std/#std.Build.Step.Compile.installHeadersDirectory) and [installHeader](https://ziglang.org/documentation/master/std/#std.Build.Step.Compile.installHeader).

`installHeadersDirectory` also needs a [HeaderInstallation.Directory.Options](https://ziglang.org/documentation/master/std/#std.Build.Step.Compile.HeaderInstallation.Directory.Options) parameter now, and I added an empty one.

*Note*: I currently have the `brotli` dependency pointing to my fork.  If that gets merged I can update the `build.zig.zon` here to point to the new `master` commit.


- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.