### PR TITLE
Chore: Fix removed APIs in std.Build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Zig
         run: |
           sudo apt install xz-utils
-          sudo sh -c 'wget -c https://pkg.machengine.org/zig/zig-linux-x86_64-0.14.0-dev.1911+3bf89f55c.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
+          sudo sh -c 'wget -c https://pkg.machengine.org/zig/zig-linux-x86_64-0.14.0-dev.2563+af5e73172.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
       - name: build
         run: zig build
   x86_64-windows:
@@ -26,10 +26,10 @@ jobs:
       - name: Setup Zig
         run: |
           $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest -Uri "https://pkg.machengine.org/zig/zig-windows-x86_64-0.14.0-dev.1911+3bf89f55c.zip" -OutFile "C:\zig.zip"
+          Invoke-WebRequest -Uri "https://pkg.machengine.org/zig/zig-windows-x86_64-0.14.0-dev.2563+af5e73172.zip" -OutFile "C:\zig.zip"
           cd C:\
           7z x zig.zip
-          Add-Content $env:GITHUB_PATH "C:\zig-windows-x86_64-0.14.0-dev.1911+3bf89f55c\"
+          Add-Content $env:GITHUB_PATH "C:\zig-windows-x86_64-0.14.0-dev.2563+af5e73172\"
       - name: build
         run: zig build
   x86_64-macos:
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Zig
         run: |
           brew install xz
-          sudo sh -c 'wget -c https://pkg.machengine.org/zig/zig-macos-x86_64-0.14.0-dev.1911+3bf89f55c.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
+          sudo sh -c 'wget -c https://pkg.machengine.org/zig/zig-macos-x86_64-0.14.0-dev.2563+af5e73172.tar.xz -O - | tar -xJ --strip-components=1 -C /usr/local/bin'
       - name: build
         run: zig build
         env:

--- a/build.zig
+++ b/build.zig
@@ -14,21 +14,21 @@ pub fn build(b: *std.Build) void {
     });
     lib.linkLibC();
     lib.addIncludePath(b.path("include"));
-    lib.defineCMacro("FT2_BUILD_LIBRARY", "1");
+    lib.root_module.addCMacro("FT2_BUILD_LIBRARY", "1");
 
     if (use_system_zlib) {
-        lib.defineCMacro("FT_CONFIG_OPTION_SYSTEM_ZLIB", "1");
+        lib.root_module.addCMacro("FT_CONFIG_OPTION_SYSTEM_ZLIB", "1");
     }
 
     if (enable_brotli) {
-        lib.defineCMacro("FT_CONFIG_OPTION_USE_BROTLI", "1");
+        lib.root_module.addCMacro("FT_CONFIG_OPTION_USE_BROTLI", "1");
         if (b.lazyDependency("brotli", .{
             .target = target,
             .optimize = optimize,
         })) |dep| lib.linkLibrary(dep.artifact("brotli"));
     }
 
-    lib.defineCMacro("HAVE_UNISTD_H", "1");
+    lib.root_module.addCMacro("HAVE_UNISTD_H", "1");
     lib.addCSourceFiles(.{ .files = &sources, .flags = &.{} });
     if (target.result.os.tag == .macos) lib.addCSourceFile(.{
         .file = b.path("src/base/ftmac.c"),


### PR DESCRIPTION
[This Zig Commit](https://github.com/ziglang/zig/commit/3d393dba6fc06cea3508aaa3db9d49042663367e) removes `dep.defineCMacro` in favor of `dep.root_module.addCMacro`.

Note that we should update `build.zig.zon` too after [this pr](https://github.com/hexops/brotli/pull/22) lands.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.
